### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Contributions are very welcome - please follow the [guidelines](CONTRIBUTING.md)
 - [Aquasoldb](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/OVHAW8): Curation of nine open source datasets on aqueous solubility. The authors also assigned reliability groups.
 - [BigSolDB](https://zenodo.org/record/6984601): Molecular solubility in organic solvents and water in a wide range of temperatures. It contains 830 unique molecules and 138 unique solvents. Temperatures range from 243.15K to 403.15K. Published in [this paper](https://chemrxiv.org/engage/chemrxiv/article-details/6426c1d8db1a20696e4c947b).
 - [BindingDB](https://www.bindingdb.org/rwd/bind/chemsearch/marvin/Download.jsp): molecular recognition database, contains 2.6M data for 1.1M Compounds and 8.10K Targets (Feb 2023)
+- [BOOM](https://github.com/FLASK-LLNL/BOOM): BOOM (**b**enchmarks for **o**ut-**o**f-distribution **m**olecules) is a out-of-distribution (OOD) benchmark for molecular property prediction comprised of QM9 and LLNL-10k-Dataset properties.
 - [ChEBI-20](https://paperswithcode.com/dataset/chebi-20): 33,010 molecule-description pairs (for molecule captioning task)
 - [ESol](https://pubmed.ncbi.nlm.nih.gov/15154768/): Water solubility data(log solubility in mols per litre) for common organic small molecules.
 - [Flashpoint](https://github.com/cheminfo/molecule-features/blob/main/data/flashpoint/meta.yaml#:~:text=https%3A//figshare.com/articles/dataset/Data_for_Assessing_Graph%2Dbased_Deep_Learning_Models_for_Predicting_Flash_Point/9275210): Sun et al. collected a dataset of the flashpoints of 10575 molecules from academic papers, the Gelest chemical catalogue, the DIPPR database, Lange's Handbook of Chemistry, the Hazardous Chemicals Handbook, and the PubChem database.
@@ -58,6 +59,7 @@ Contributions are very welcome - please follow the [guidelines](CONTRIBUTING.md)
 - [Leffingwell Odor Dataset](https://zenodo.org/record/4085098): 3523 molecules associated with expert-labeled odor descriptors from the Leffingwell PMP 2001 database
 - [Limiting activity coefficients](https://polybox.ethz.ch/index.php/s/kyVOt3pwHW26PP4): for different solvent/solute pairs, used to train a SMILES-based transformer.
 - [Lipophilicty](https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/Lipophilicity.csv): Experimental results of octanol/water distribution coefficient(logD at pH 7.4).
+- [LLNL-10k-Dataset](https://github.com/FLASK-LLNL/LLNL-10k-Dataset): DFT calculated density and solid heat of formation values for ~10k CHNO molecules.
 - [MD simulated monomer properties](https://acdc.alcf.anl.gov/mdf/detail/elwood_md_v1.2/): density, cohesive energy, thermal expansion, heat of vaporization, compressibility, radius of gyration, glass transition, and diffusion constant for 410 monomers
 - [MoleculeNet](https://moleculenet.org/datasets-1) - Benchmark suite that contains multiple datasets listed here
 - [oechem](https://ochem.eu/): On Feb 17 2023 OCHEM contained 3774118 records for 689 properties (with at least 50 records) collected from 20609 sources (user is granted a Creative Commons CC-BY (version 4.0) license to data submitted)


### PR DESCRIPTION
Added BOOM and LLNL-10k-Dataset both to the "structure-property benchmark datasets" section

## Summary by Sourcery

Add BOOM and LLNL-10k-Dataset entries to the structure-property benchmark datasets section of README.md

Documentation:
- Add BOOM as a structure-property benchmark dataset entry
- Add LLNL-10k-Dataset as a structure-property benchmark dataset entry